### PR TITLE
[WIP] Script remote type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "remote-oss",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "remote-oss",
-            "version": "0.0.2",
+            "version": "0.0.3",
             "license": "MIT",
             "devDependencies": {
                 "@types/glob": "^7.2.0",
@@ -17,6 +17,7 @@
                 "@typescript-eslint/parser": "^5.21.0",
                 "eslint": "^8.14.0",
                 "mocha": "^9.2.2",
+                "prettier": "^3.0.2",
                 "ts-loader": "^9.3.0",
                 "ts-node": "^10.7.0",
                 "typescript": "^4.6.4",
@@ -2840,6 +2841,21 @@
             "dev": true,
             "engines": {
                 "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/prettier": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.2.tgz",
+            "integrity": "sha512-o2YR9qtniXvwEZlOKbveKfDQVyqxbEIWn48Z8m3ZJjBjcCmUy3xZGIv+7AkaeuaTr6yPXJjwv07ZWlsWbEy1rQ==",
+            "dev": true,
+            "bin": {
+                "prettier": "bin/prettier.cjs"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/prettier/prettier?sponsor=1"
             }
         },
         "node_modules/pump": {
@@ -6125,6 +6141,12 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
             "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+            "dev": true
+        },
+        "prettier": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.2.tgz",
+            "integrity": "sha512-o2YR9qtniXvwEZlOKbveKfDQVyqxbEIWn48Z8m3ZJjBjcCmUy3xZGIv+7AkaeuaTr6yPXJjwv07ZWlsWbEy1rQ==",
             "dev": true
         },
         "pump": {

--- a/package.json
+++ b/package.json
@@ -182,6 +182,7 @@
             "oneOf": [
               {
                 "required": [
+                  "type",
                   "host",
                   "port"
                 ],
@@ -212,6 +213,54 @@
                       "const": true
                     },
                     "description": "Assume that the server was started wit this connection token. Use false to disable connection tokens. Use true to ask for a token before connecting."
+                  }
+                }
+              },
+              {
+                "required": [
+                  "type",
+                  "host",
+                  "port"
+                ],
+                "properties": {
+                  "type": {
+                    "const": "script"
+                  },
+                  "host": {
+                    "type": "string",
+                    "description": "Specifies the host name or IP address of the host to connect to."
+                  },
+                  "port": {
+                    "type": "number",
+                    "description": "Specifies the port to connect to.",
+                    "minimum": 1025,
+                    "maximum": 65535
+                  },
+                  "connectionToken": {
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "boolean"
+                      }
+                    ],
+                    "default": {
+                      "const": true
+                    },
+                    "description": "Assume that the server was started wit this connection token. Use false to disable connection tokens. Use true to ask for a token before connecting."
+                  },
+                  "localDirectory": {
+                    "type": "string",
+                    "description": "Local directory to run scripts in."
+                  },
+                  "listenScript": {
+                    "type": "string",
+                    "description": "Script that runs an REH on the configured host/port."
+                  },
+                  "listenScriptReady": {
+                    "type": "string",
+                    "description": "Regular expression that listenScript outputs once it is ready to receive connections. Default: \"Extension host agent listening\""
                   }
                 }
               }

--- a/package.json
+++ b/package.json
@@ -1,247 +1,248 @@
 {
-    "name": "remote-oss",
-    "displayName": "Remote (OSS)",
-    "description": "Remote (OSS)",
-    "version": "0.0.3",
-    "publisher": "xaberus",
-    "repository": {
-        "url": "https://github.com/xaberus/vscode-remote-oss"
-    },
-    "license": "MIT",
-    "engines": {
-        "vscode": "^1.67.0"
-    },
-    "extensionKind": [
-        "ui"
-    ],
-    "enabledApiProposals": [
-        "resolvers",
-        "terminalDataWriteEvent",
-        "contribViewsRemote"
-    ],
-    "categories": [
-        "Other"
-    ],
-    "activationEvents": [
-        "onResolveRemoteAuthority:remote-oss",
-        "onCommand:remote-oss.openEmptyWindowInCurrentWindow",
-        "onCommand:remote-oss.openFolderInCurrentWindow",
-        "onCommand:remote-oss.showLog",
-        "onView:remoteHosts"
-    ],
-    "main": "./out/extension.js",
-    "capabilities": {
-        "untrustedWorkspaces": {
-            "supported": true
-        }
-    },
-    "contributes": {
-        "views": {
-            "remote": [
-                {
-                    "id": "remoteHosts",
-                    "name": "Remote Hosts",
-                    "group": "targets@1",
-                    "remoteName": "remote-oss"
-                }
-            ]
-        },
-        "viewsWelcome": [
-            {
-                "view": "remoteHosts",
-                "when": "remote-oss:noHosts",
-                "contents": "No remote hosts have been configured yet."
-            }
-        ],
-        "commands": [
-            {
-                "command": "remote-oss.configureHosts",
-                "title": "Configure",
-                "icon": "$(gear)"
-            },
-            {
-                "command": "remote-oss.openEmptyWindowInCurrentWindow",
-                "title": "Connect Current Window to Host...",
-                "category": "Remote-OSS",
-                "icon": "$(empty-window)"
-            },
-            {
-                "command": "remote-oss.openFolderInCurrentWindow",
-                "title": "Connect Current Window to Folder on Host...",
-                "category": "Remote-OSS",
-                "icon": "$(empty-window)"
-            },
-            {
-                "command": "remote-oss.showLog",
-                "title": "Show Log",
-                "category": "Remote-OSS"
-            }
-        ],
-        "resourceLabelFormatters": [
-            {
-                "scheme": "vscode-remote",
-                "authority": "remote-oss+*",
-                "formatting": {
-                    "label": "${path}",
-                    "separator": "/",
-                    "tildify": true,
-                    "workspaceSuffix": "remote"
-                }
-            }
-        ],
-        "menus": {
-            "statusBar/remoteIndicator": [
-                {
-                    "command": "remote-oss.openEmptyWindowInCurrentWindow",
-                    "when": "true",
-                    "group": "remote_20_oss_1general@1"
-                },
-                {
-                    "command": "remote-oss.showLog",
-                    "when": "true",
-                    "group": "remote_20_oss_1general@4"
-                }
-            ],
-            "view/title": [
-                {
-                    "command": "remote-oss.configureHosts",
-                    "when": "view == remoteHosts",
-                    "group": "navigation"
-                }
-            ],
-            "view/item/context": [
-                {
-                    "command": "remote-oss.openEmptyWindowInCurrentWindow",
-                    "when": "viewItem == remote-oss.host",
-                    "group": "inline@1"
-                },
-                {
-                    "command": "remote-oss.openFolderInCurrentWindow",
-                    "when": "viewItem == remote-oss.folder",
-                    "group": "inline@1"
-                }
-            ]
-        },
-        "configuration": {
-            "title": "Remote - OSS",
-            "properties": {
-                "remote.OSS.hosts": {
-                    "description": "Specify a list of hosts here that you want to connect to remotely.",
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "required": [
-                            "type",
-                            "name"
-                        ],
-                        "properties": {
-                            "type": {
-                                "type": "string",
-                                "description": "Specify the type of connection this is.",
-                                "enum": [
-                                    "manual"
-                                ],
-                                "enumDescriptions": [
-                                    "A manual connection that you will establish yourself. In particular, you are responsible for starting the correct server version and creating a tunnel from the specified port to the remote port the server is listening to."
-                                ]
-                            },
-                            "name": {
-                                "type": "string",
-                                "description": "Specifies the label to be used for this connection."
-                            },
-                            "folders": {
-                                "type": "array",
-                                "description": "Specifies a short cut list of workspace folders on the remote host.",
-                                "items": {
-                                    "oneOf": [
-                                        {
-                                            "type": "string",
-                                            "description": "Specifies the path on the remote host."
-                                        },
-                                        {
-                                            "type": "object",
-                                            "required": [
-                                                "name",
-                                                "path"
-                                            ],
-                                            "properties": {
-                                                "name": {
-                                                    "type": "string",
-                                                    "description": "Specifies a label to use instead of the full path."
-                                                },
-                                                "path": {
-                                                    "type": "string",
-                                                    "description": "Specifies the path on the remote host."
-                                                }
-                                            }
-                                        }
-                                    ]
-                                }
-                            }
-                        },
-                        "oneOf": [
-                            {
-                                "required": [
-                                    "host",
-                                    "port"
-                                ],
-                                "properties": {
-                                    "type": {
-                                        "const": "manual"
-                                    },
-                                    "host": {
-                                        "type": "string",
-                                        "description": "Specifies the host name or IP address of the host to connect to."
-                                    },
-                                    "port": {
-                                        "type": "number",
-                                        "description": "Specifies the port to connect to.",
-                                        "minimum": 1025,
-                                        "maximum": 65535
-                                    },
-                                    "connectionToken": {
-                                        "oneOf": [
-                                            {
-                                                "type": "string"
-                                            },
-                                            {
-                                                "type": "boolean"
-                                            }
-                                        ],
-                                        "default": {
-                                            "const": true
-                                        },
-                                        "description": "Assume that the server was started wit this connection token. Use false to disable connection tokens. Use true to ask for a token before connecting."
-                                    }
-                                }
-                            }
-                        ],
-                        "unevaluatedProperties": false
-                    }
-                }
-            }
-        }
-    },
-    "scripts": {
-        "vscode:prepublish": "npm run compile",
-        "compile": "tsc -p ./",
-        "watch": "tsc -watch -p ./",
-        "pretest": "npm run compile && npm run lint",
-        "lint": "eslint src --ext ts",
-        "package": "vsce package"
-    },
-    "devDependencies": {
-        "@types/glob": "^7.2.0",
-        "@types/mocha": "^9.1.1",
-        "@types/node": "14.x",
-        "@types/vscode": "^1.67.0",
-        "@typescript-eslint/eslint-plugin": "^5.21.0",
-        "@typescript-eslint/parser": "^5.21.0",
-        "eslint": "^8.14.0",
-        "mocha": "^9.2.2",
-        "ts-loader": "^9.3.0",
-        "ts-node": "^10.7.0",
-        "typescript": "^4.6.4",
-        "vsce": "^2.9.1"
+  "name": "remote-oss",
+  "displayName": "Remote (OSS)",
+  "description": "Remote (OSS)",
+  "version": "0.0.3",
+  "publisher": "xaberus",
+  "repository": {
+    "url": "https://github.com/xaberus/vscode-remote-oss"
+  },
+  "license": "MIT",
+  "engines": {
+    "vscode": "^1.67.0"
+  },
+  "extensionKind": [
+    "ui"
+  ],
+  "enabledApiProposals": [
+    "resolvers",
+    "terminalDataWriteEvent",
+    "contribViewsRemote"
+  ],
+  "categories": [
+    "Other"
+  ],
+  "activationEvents": [
+    "onResolveRemoteAuthority:remote-oss",
+    "onCommand:remote-oss.openEmptyWindowInCurrentWindow",
+    "onCommand:remote-oss.openFolderInCurrentWindow",
+    "onCommand:remote-oss.showLog",
+    "onView:remoteHosts"
+  ],
+  "main": "./out/extension.js",
+  "capabilities": {
+    "untrustedWorkspaces": {
+      "supported": true
     }
+  },
+  "contributes": {
+    "views": {
+      "remote": [
+        {
+          "id": "remoteHosts",
+          "name": "Remote Hosts",
+          "group": "targets@1",
+          "remoteName": "remote-oss"
+        }
+      ]
+    },
+    "viewsWelcome": [
+      {
+        "view": "remoteHosts",
+        "when": "remote-oss:noHosts",
+        "contents": "No remote hosts have been configured yet."
+      }
+    ],
+    "commands": [
+      {
+        "command": "remote-oss.configureHosts",
+        "title": "Configure",
+        "icon": "$(gear)"
+      },
+      {
+        "command": "remote-oss.openEmptyWindowInCurrentWindow",
+        "title": "Connect Current Window to Host...",
+        "category": "Remote-OSS",
+        "icon": "$(empty-window)"
+      },
+      {
+        "command": "remote-oss.openFolderInCurrentWindow",
+        "title": "Connect Current Window to Folder on Host...",
+        "category": "Remote-OSS",
+        "icon": "$(empty-window)"
+      },
+      {
+        "command": "remote-oss.showLog",
+        "title": "Show Log",
+        "category": "Remote-OSS"
+      }
+    ],
+    "resourceLabelFormatters": [
+      {
+        "scheme": "vscode-remote",
+        "authority": "remote-oss+*",
+        "formatting": {
+          "label": "${path}",
+          "separator": "/",
+          "tildify": true,
+          "workspaceSuffix": "remote"
+        }
+      }
+    ],
+    "menus": {
+      "statusBar/remoteIndicator": [
+        {
+          "command": "remote-oss.openEmptyWindowInCurrentWindow",
+          "when": "true",
+          "group": "remote_20_oss_1general@1"
+        },
+        {
+          "command": "remote-oss.showLog",
+          "when": "true",
+          "group": "remote_20_oss_1general@4"
+        }
+      ],
+      "view/title": [
+        {
+          "command": "remote-oss.configureHosts",
+          "when": "view == remoteHosts",
+          "group": "navigation"
+        }
+      ],
+      "view/item/context": [
+        {
+          "command": "remote-oss.openEmptyWindowInCurrentWindow",
+          "when": "viewItem == remote-oss.host",
+          "group": "inline@1"
+        },
+        {
+          "command": "remote-oss.openFolderInCurrentWindow",
+          "when": "viewItem == remote-oss.folder",
+          "group": "inline@1"
+        }
+      ]
+    },
+    "configuration": {
+      "title": "Remote - OSS",
+      "properties": {
+        "remote.OSS.hosts": {
+          "description": "Specify a list of hosts here that you want to connect to remotely.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "type",
+              "name"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "description": "Specify the type of connection this is.",
+                "enum": [
+                  "manual"
+                ],
+                "enumDescriptions": [
+                  "A manual connection that you will establish yourself. In particular, you are responsible for starting the correct server version and creating a tunnel from the specified port to the remote port the server is listening to."
+                ]
+              },
+              "name": {
+                "type": "string",
+                "description": "Specifies the label to be used for this connection."
+              },
+              "folders": {
+                "type": "array",
+                "description": "Specifies a short cut list of workspace folders on the remote host.",
+                "items": {
+                  "oneOf": [
+                    {
+                      "type": "string",
+                      "description": "Specifies the path on the remote host."
+                    },
+                    {
+                      "type": "object",
+                      "required": [
+                        "name",
+                        "path"
+                      ],
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "description": "Specifies a label to use instead of the full path."
+                        },
+                        "path": {
+                          "type": "string",
+                          "description": "Specifies the path on the remote host."
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "oneOf": [
+              {
+                "required": [
+                  "host",
+                  "port"
+                ],
+                "properties": {
+                  "type": {
+                    "const": "manual"
+                  },
+                  "host": {
+                    "type": "string",
+                    "description": "Specifies the host name or IP address of the host to connect to."
+                  },
+                  "port": {
+                    "type": "number",
+                    "description": "Specifies the port to connect to.",
+                    "minimum": 1025,
+                    "maximum": 65535
+                  },
+                  "connectionToken": {
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "boolean"
+                      }
+                    ],
+                    "default": {
+                      "const": true
+                    },
+                    "description": "Assume that the server was started wit this connection token. Use false to disable connection tokens. Use true to ask for a token before connecting."
+                  }
+                }
+              }
+            ],
+            "unevaluatedProperties": false
+          }
+        }
+      }
+    }
+  },
+  "scripts": {
+    "vscode:prepublish": "npm run compile",
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./",
+    "pretest": "npm run compile && npm run lint",
+    "lint": "eslint src --ext ts",
+    "package": "vsce package"
+  },
+  "devDependencies": {
+    "@types/glob": "^7.2.0",
+    "@types/mocha": "^9.1.1",
+    "@types/node": "14.x",
+    "@types/vscode": "^1.67.0",
+    "@typescript-eslint/eslint-plugin": "^5.21.0",
+    "@typescript-eslint/parser": "^5.21.0",
+    "eslint": "^8.14.0",
+    "mocha": "^9.2.2",
+    "prettier": "^3.0.2",
+    "ts-loader": "^9.3.0",
+    "ts-node": "^10.7.0",
+    "typescript": "^4.6.4",
+    "vsce": "^2.9.1"
+  }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,98 +1,127 @@
-import * as vscode from 'vscode';
-import { RemotesDataProvider, FolderItem, HostBase } from './remotesView';
+import * as vscode from "vscode";
+import { RemotesDataProvider, FolderItem, HostBase } from "./remotesView";
 
 let outputChannel: vscode.OutputChannel;
 
-
-function registerExplorer(context: vscode.ExtensionContext): RemotesDataProvider {
-    let treeDataProvider = new RemotesDataProvider(context);
-    const view = vscode.window.createTreeView('remoteHosts', {
-        treeDataProvider: treeDataProvider,
-        showCollapseAll: true,
-    });
-    context.subscriptions.push(view);
-    return treeDataProvider;
+function registerExplorer(
+  context: vscode.ExtensionContext,
+): RemotesDataProvider {
+  let treeDataProvider = new RemotesDataProvider(context);
+  const view = vscode.window.createTreeView("remoteHosts", {
+    treeDataProvider: treeDataProvider,
+    showCollapseAll: true,
+  });
+  context.subscriptions.push(view);
+  return treeDataProvider;
 }
 
 export function activate(context: vscode.ExtensionContext) {
-    let remotesProvider = registerExplorer(context);
-    context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(async (e) => {
-        if (e.affectsConfiguration('remote.OSS.hosts')) {
-            await remotesProvider.readTree();
+  let remotesProvider = registerExplorer(context);
+  context.subscriptions.push(
+    vscode.workspace.onDidChangeConfiguration(async (e) => {
+      if (e.affectsConfiguration("remote.OSS.hosts")) {
+        await remotesProvider.readTree();
+      }
+    }),
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("remote-oss.configureHosts", async () => {
+      vscode.commands.executeCommand("workbench.action.openSettingsJson");
+    }),
+  );
+
+  function doResolve(
+    label: string,
+    progress: vscode.Progress<{ message?: string; increment?: number }>,
+  ): Promise<vscode.ResolvedAuthority> {
+    outputChannel = vscode.window.createOutputChannel("Remote OSS");
+    const authority = remotesProvider.resolveAuthority(label, outputChannel);
+    context.subscriptions.push(
+      vscode.workspace.registerResourceLabelFormatter({
+        scheme: "vscode-remote",
+        authority: "remote-oss+*",
+        formatting: {
+          label: "${path}",
+          separator: "/",
+          tildify: true,
+          workspaceSuffix: label,
+        },
+      }),
+    );
+    // Enable ports view
+    vscode.commands.executeCommand(
+      "setContext",
+      "forwardedPortsViewEnabled",
+      true,
+    );
+    return authority;
+  }
+
+  const authorityResolverDisposable =
+    vscode.workspace.registerRemoteAuthorityResolver("remote-oss", {
+      async getCanonicalURI(uri: vscode.Uri): Promise<vscode.Uri> {
+        return vscode.Uri.file(uri.path);
+      },
+      resolve(authority: string): Thenable<vscode.ResolvedAuthority> {
+        const match = authority.match(/remote-oss\+(.*)/);
+        if (match) {
+          return vscode.window.withProgress(
+            {
+              location: vscode.ProgressLocation.Notification,
+              title: `connecting to ${match[1]} ([details](command:remote-oss.showLog))`,
+              cancellable: false,
+            },
+            (progress) => doResolve(match[1], progress),
+          );
         }
-    }));
-
-    context.subscriptions.push(vscode.commands.registerCommand('remote-oss.configureHosts', async () => {
-        vscode.commands.executeCommand("workbench.action.openSettingsJson");
-    }));
-
-    function doResolve(label: string, progress: vscode.Progress<{ message?: string; increment?: number }>): Promise<vscode.ResolvedAuthority> {
-        outputChannel = vscode.window.createOutputChannel('Remote OSS');
-        const authority = remotesProvider.resolveAuthority(label, outputChannel);
-        context.subscriptions.push(vscode.workspace.registerResourceLabelFormatter({
-            scheme: "vscode-remote",
-            authority: "remote-oss+*",
-            formatting: {
-                label: "${path}",
-                separator: "/",
-                tildify: true,
-                workspaceSuffix: label
-            }
-        }));
-        // Enable ports view
-        vscode.commands.executeCommand("setContext", "forwardedPortsViewEnabled", true);
-        return authority;
-    }
-
-    const authorityResolverDisposable = vscode.workspace.registerRemoteAuthorityResolver('remote-oss', {
-        async getCanonicalURI(uri: vscode.Uri): Promise<vscode.Uri> {
-            return vscode.Uri.file(uri.path);
-        },
-        resolve(authority: string): Thenable<vscode.ResolvedAuthority> {
-            const match = authority.match(/remote-oss\+(.*)/);
-            if (match) {
-                return vscode.window.withProgress({
-                    location: vscode.ProgressLocation.Notification,
-                    title: `connecting to ${match[1]} ([details](command:remote-oss.showLog))`,
-                    cancellable: false
-                }, (progress) => doResolve(match[1], progress));
-            }
-            throw vscode.RemoteAuthorityResolverError.NotAvailable('Invalid', true);
-        },
-        // tunnelFactory,
-        // showCandidatePort
+        throw vscode.RemoteAuthorityResolverError.NotAvailable("Invalid", true);
+      },
+      // tunnelFactory,
+      // showCandidatePort
     });
-    context.subscriptions.push(authorityResolverDisposable);
+  context.subscriptions.push(authorityResolverDisposable);
 
-
-    context.subscriptions.push(vscode.commands.registerCommand('remote-oss.openEmptyWindowInCurrentWindow',
-        async (host?: HostBase) => {
-            var label: string | undefined = undefined;
-            if (!host) {
-                label = await remotesProvider.pickHost();
-            } else {
-                label = `remote-oss+${host.name}`;
-            }
-            if (label) {
-                vscode.window.showInformationMessage('resolving remote');
-                vscode.commands.executeCommand("vscode.newWindow", {
-                    remoteAuthority: label,
-                    reuseWindow: true
-                });
-            }
-        }));
-
-    context.subscriptions.push(vscode.commands.registerCommand('remote-oss.openFolderInCurrentWindow',
-        async (folder: FolderItem) => {
-            const uri = vscode.Uri.parse(`vscode-remote://remote-oss+${folder.host}${folder.path}`);
-            vscode.commands.executeCommand("vscode.openFolder", uri);
-        }));
-
-    context.subscriptions.push(vscode.commands.registerCommand('remote-oss.showLog', () => {
-        if (outputChannel) {
-            outputChannel.show();
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "remote-oss.openEmptyWindowInCurrentWindow",
+      async (host?: HostBase) => {
+        var label: string | undefined = undefined;
+        if (!host) {
+          label = await remotesProvider.pickHost();
+        } else {
+          label = `remote-oss+${host.name}`;
         }
-    }));
+        if (label) {
+          vscode.window.showInformationMessage("resolving remote");
+          vscode.commands.executeCommand("vscode.newWindow", {
+            remoteAuthority: label,
+            reuseWindow: true,
+          });
+        }
+      },
+    ),
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "remote-oss.openFolderInCurrentWindow",
+      async (folder: FolderItem) => {
+        const uri = vscode.Uri.parse(
+          `vscode-remote://remote-oss+${folder.host}${folder.path}`,
+        );
+        vscode.commands.executeCommand("vscode.openFolder", uri);
+      },
+    ),
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("remote-oss.showLog", () => {
+      if (outputChannel) {
+        outputChannel.show();
+      }
+    }),
+  );
 }
 
-export function deactivate() { }
+export function deactivate() {}

--- a/src/remotesConfig.ts
+++ b/src/remotesConfig.ts
@@ -1,5 +1,6 @@
 export enum HostKind {
   Manual = "manual",
+  Script = "script",
 }
 
 export interface ExtendedHostFolder {
@@ -21,4 +22,14 @@ export interface ManualHostConfig extends HostConfigBase {
   connectionToken?: string | boolean;
 }
 
-export type HostConfig = ManualHostConfig;
+export interface ScriptHostConfig extends HostConfigBase {
+  type: HostKind.Script;
+  host: string;
+  port: number;
+  connectionToken?: string | boolean;
+  localDirectory: string;
+  listenScript: string;
+  listenScriptReady?: string;
+}
+
+export type HostConfig = ManualHostConfig | ScriptHostConfig;

--- a/src/remotesConfig.ts
+++ b/src/remotesConfig.ts
@@ -1,24 +1,24 @@
 export enum HostKind {
-    Manual = "manual",
+  Manual = "manual",
 }
 
 export interface ExtendedHostFolder {
-    name: string;
-    path: string;
+  name: string;
+  path: string;
 }
 
 export type HostFolder = string | ExtendedHostFolder;
 export interface HostConfigBase {
-    type: string;
-    name: string;
-    folders?: [HostFolder];
+  type: string;
+  name: string;
+  folders?: [HostFolder];
 }
 
 export interface ManualHostConfig extends HostConfigBase {
-    type: HostKind.Manual;
-    host: string;
-    port: number;
-    connectionToken?: string | boolean;
+  type: HostKind.Manual;
+  host: string;
+  port: number;
+  connectionToken?: string | boolean;
 }
 
 export type HostConfig = ManualHostConfig;

--- a/src/remotesView.ts
+++ b/src/remotesView.ts
@@ -1,255 +1,275 @@
 import {
-    commands,
-    Event, EventEmitter,
-    ExtensionContext,
-    OutputChannel,
-    QuickPickItem,
-    RemoteAuthorityResolverError,
-    ResolvedAuthority,
-    ThemeIcon,
-    TreeDataProvider,
-    TreeItem,
-    TreeItemCollapsibleState,
-    window,
-    workspace
+  commands,
+  Event,
+  EventEmitter,
+  ExtensionContext,
+  OutputChannel,
+  QuickPickItem,
+  RemoteAuthorityResolverError,
+  ResolvedAuthority,
+  ThemeIcon,
+  TreeDataProvider,
+  TreeItem,
+  TreeItemCollapsibleState,
+  window,
+  workspace,
 } from "vscode";
 import { HostConfig, HostKind } from "./remotesConfig";
 
 export class HostBase extends TreeItem {
-    name: string;
-    folders: FolderItem[];
+  name: string;
+  folders: FolderItem[];
 
-    constructor(label: string) {
-        super(label, TreeItemCollapsibleState.None);
-        this.name = label;
-        this.folders = [];
-    }
+  constructor(label: string) {
+    super(label, TreeItemCollapsibleState.None);
+    this.name = label;
+    this.folders = [];
+  }
 
-    addFolder(folder: FolderItem) {
-        this.folders.push(folder);
-        this.collapsibleState = TreeItemCollapsibleState.Expanded;
-    }
+  addFolder(folder: FolderItem) {
+    this.folders.push(folder);
+    this.collapsibleState = TreeItemCollapsibleState.Expanded;
+  }
 }
 
 export class FolderItem extends TreeItem {
-    readonly host: string;
-    readonly path: string;
-    constructor(label: string, host: string, path: string) {
-        super(label, TreeItemCollapsibleState.None);
-        this.contextValue = 'remote-oss.folder';
-        this.iconPath = ThemeIcon.Folder;
-        this.host = host;
-        this.path = path;
-    }
+  readonly host: string;
+  readonly path: string;
+  constructor(label: string, host: string, path: string) {
+    super(label, TreeItemCollapsibleState.None);
+    this.contextValue = "remote-oss.folder";
+    this.iconPath = ThemeIcon.Folder;
+    this.host = host;
+    this.path = path;
+  }
 }
 
 class PlainHostItem extends HostBase {
-    readonly host: string;
-    readonly port: number;
-    readonly connectionToken: string | boolean;
+  readonly host: string;
+  readonly port: number;
+  readonly connectionToken: string | boolean;
 
-    constructor(label: string, host: string, port: number, connectionToken: string | boolean) {
-        super(label);
-        this.contextValue = 'remote-oss.host';
-        this.iconPath = new ThemeIcon("device-desktop");
-        this.description = `${host}:${port}`;
-        this.host = host;
-        this.port = port;
-        this.connectionToken = connectionToken;
-    }
+  constructor(
+    label: string,
+    host: string,
+    port: number,
+    connectionToken: string | boolean,
+  ) {
+    super(label);
+    this.contextValue = "remote-oss.host";
+    this.iconPath = new ThemeIcon("device-desktop");
+    this.description = `${host}:${port}`;
+    this.host = host;
+    this.port = port;
+    this.connectionToken = connectionToken;
+  }
 }
-
-
 
 type Host = PlainHostItem;
 
 class KindItem extends TreeItem {
-    hosts: Host[] = [];
+  hosts: Host[] = [];
 
-    constructor(label: string, description?: string) {
-        super(label, TreeItemCollapsibleState.Expanded);
-        this.contextValue = 'remote-oss.kind';
-        this.iconPath = ThemeIcon.Folder;
-        this.description = description;
-    }
+  constructor(label: string, description?: string) {
+    super(label, TreeItemCollapsibleState.Expanded);
+    this.contextValue = "remote-oss.kind";
+    this.iconPath = ThemeIcon.Folder;
+    this.description = description;
+  }
 
-    addHost(host: Host) {
-        this.hosts.push(host);
-    }
+  addHost(host: Host) {
+    this.hosts.push(host);
+  }
 }
-
 
 type TaskTree = KindItem[] | Host[];
 
-export class RemotesDataProvider implements TreeDataProvider<TreeItem>{
-    private remotesTree: TaskTree | null = null;
-    private extensionContext: ExtensionContext;
-    private _onDidChangeTreeData: EventEmitter<TreeItem | null> = new EventEmitter<TreeItem | null>();
-    readonly onDidChangeTreeData: Event<TreeItem | null> = this._onDidChangeTreeData.event;
+export class RemotesDataProvider implements TreeDataProvider<TreeItem> {
+  private remotesTree: TaskTree | null = null;
+  private extensionContext: ExtensionContext;
+  private _onDidChangeTreeData: EventEmitter<TreeItem | null> =
+    new EventEmitter<TreeItem | null>();
+  readonly onDidChangeTreeData: Event<TreeItem | null> =
+    this._onDidChangeTreeData.event;
 
-    constructor(private context: ExtensionContext) {
-        const subscriptions = context.subscriptions;
-        this.extensionContext = context;
-    }
+  constructor(private context: ExtensionContext) {
+    const subscriptions = context.subscriptions;
+    this.extensionContext = context;
+  }
 
-    getTreeItem(element: TreeItem): TreeItem {
-        return element;
-    }
+  getTreeItem(element: TreeItem): TreeItem {
+    return element;
+  }
 
-    getParent(element: TreeItem): TreeItem | null {
-        return null;
-    }
+  getParent(element: TreeItem): TreeItem | null {
+    return null;
+  }
 
-    async setNoHostsContext(enabled: boolean) {
-        await commands.executeCommand("setContext", "remote-oss:noHosts", enabled);
-    }
+  async setNoHostsContext(enabled: boolean) {
+    await commands.executeCommand("setContext", "remote-oss:noHosts", enabled);
+  }
 
-    async readTree() {
-        let tree = [];
+  async readTree() {
+    let tree = [];
 
-        var numberOfHosts = 0;
-        const value: any = workspace.getConfiguration().get("remote.OSS.hosts");
-        if (value) {
-            let manual = new KindItem("manual");
-            const hosts: HostConfig[] = value;
-            for (const host of hosts) {
-                if (host.type === HostKind.Manual) {
-                    var connectionToken = host.connectionToken;
-                    if (!connectionToken && typeof connectionToken !== "boolean") {
-                        connectionToken = true;
-                    }
+    var numberOfHosts = 0;
+    const value: any = workspace.getConfiguration().get("remote.OSS.hosts");
+    if (value) {
+      let manual = new KindItem("manual");
+      const hosts: HostConfig[] = value;
+      for (const host of hosts) {
+        if (host.type === HostKind.Manual) {
+          var connectionToken = host.connectionToken;
+          if (!connectionToken && typeof connectionToken !== "boolean") {
+            connectionToken = true;
+          }
 
-                    const hostItem = new PlainHostItem(host.name, host.host, host.port, connectionToken);
-                    manual.addHost(hostItem);
-                    numberOfHosts += 1;
-                    if (host.folders) {
-                        for (const folder of host.folders) {
-                            const hostName = hostItem.label;
-                            if (typeof hostName !== "string") { continue; }
-                            if (typeof folder === "string") {
-                                hostItem.addFolder(new FolderItem(
-                                    folder,
-                                    hostName,
-                                    folder
-                                ));
-                            } else {
-                                hostItem.addFolder(new FolderItem(
-                                    folder.name,
-                                    hostName,
-                                    folder.path
-                                ));
-                            }
-                        }
-                    }
-                }
+          const hostItem = new PlainHostItem(
+            host.name,
+            host.host,
+            host.port,
+            connectionToken,
+          );
+          manual.addHost(hostItem);
+          numberOfHosts += 1;
+          if (host.folders) {
+            for (const folder of host.folders) {
+              const hostName = hostItem.label;
+              if (typeof hostName !== "string") {
+                continue;
+              }
+              if (typeof folder === "string") {
+                hostItem.addFolder(new FolderItem(folder, hostName, folder));
+              } else {
+                hostItem.addFolder(
+                  new FolderItem(folder.name, hostName, folder.path),
+                );
+              }
             }
-            if (manual.hosts.length > 0) {
-                tree.push(manual);
-            }
+          }
         }
-
-        await this.setNoHostsContext(numberOfHosts === 0);
-
-        this.remotesTree = tree;
-        this._onDidChangeTreeData.fire(null);
+      }
+      if (manual.hosts.length > 0) {
+        tree.push(manual);
+      }
     }
 
-    async getChildren(element?: TreeItem): Promise<TreeItem[]> {
-        if (!this.remotesTree) {
-            await this.readTree();
-        }
-        if (element instanceof PlainHostItem) {
-            return element.folders;
-        }
-        if (element instanceof KindItem) {
-            return element.hosts;
-        }
-        if (!element) {
-            if (this.remotesTree) {
-                return this.remotesTree;
-            }
-        }
-        return [];
+    await this.setNoHostsContext(numberOfHosts === 0);
+
+    this.remotesTree = tree;
+    this._onDidChangeTreeData.fire(null);
+  }
+
+  async getChildren(element?: TreeItem): Promise<TreeItem[]> {
+    if (!this.remotesTree) {
+      await this.readTree();
     }
-
-    async _getHostList(out: Host[], root: TreeItem[]) {
-        for (let entry of root) {
-            if (entry instanceof PlainHostItem) {
-                out.push(entry);
-            } else {
-                await this._getHostList(out, await this.getChildren(entry));
-            }
-        }
+    if (element instanceof PlainHostItem) {
+      return element.folders;
     }
-
-    async getHostList(): Promise<Host[]> {
-        let out: Host[] = [];
-        await this._getHostList(out, await this.getChildren());
-        return out;
+    if (element instanceof KindItem) {
+      return element.hosts;
     }
+    if (!element) {
+      if (this.remotesTree) {
+        return this.remotesTree;
+      }
+    }
+    return [];
+  }
 
-    async pickHost(): Promise<string | undefined> {
-        const quickpick = window.createQuickPick();
-        quickpick.canSelectMany = false;
-        quickpick.show();
+  async _getHostList(out: Host[], root: TreeItem[]) {
+    for (let entry of root) {
+      if (entry instanceof PlainHostItem) {
+        out.push(entry);
+      } else {
+        await this._getHostList(out, await this.getChildren(entry));
+      }
+    }
+  }
 
-        try {
-            quickpick.busy = true;
+  async getHostList(): Promise<Host[]> {
+    let out: Host[] = [];
+    await this._getHostList(out, await this.getChildren());
+    return out;
+  }
 
-            quickpick.items = (await this.getHostList()).map(h => ({ label: `${h.label}` }));
-            quickpick.busy = false;
+  async pickHost(): Promise<string | undefined> {
+    const quickpick = window.createQuickPick();
+    quickpick.canSelectMany = false;
+    quickpick.show();
 
-            const result = await Promise.race([
-                new Promise<readonly QuickPickItem[]>(c => quickpick.onDidAccept(() => c(quickpick.selectedItems))),
-                new Promise<undefined>(c => quickpick.onDidHide(() => c(undefined)))
-            ]);
+    try {
+      quickpick.busy = true;
 
-            if (!result || result.length === 0) {
-                return;
-            }
+      quickpick.items = (await this.getHostList()).map((h) => ({
+        label: `${h.label}`,
+      }));
+      quickpick.busy = false;
 
-            let host = result[0].label;
-            return `remote-oss+${host}`;
-        } finally {
-            quickpick.dispose();
-        }
+      const result = await Promise.race([
+        new Promise<readonly QuickPickItem[]>((c) =>
+          quickpick.onDidAccept(() => c(quickpick.selectedItems)),
+        ),
+        new Promise<undefined>((c) => quickpick.onDidHide(() => c(undefined))),
+      ]);
+
+      if (!result || result.length === 0) {
         return;
+      }
+
+      let host = result[0].label;
+      return `remote-oss+${host}`;
+    } finally {
+      quickpick.dispose();
     }
+    return;
+  }
 
-    async pickToken(): Promise<string | undefined> {
-        const raw = await window.showInputBox({
-            placeHolder: "enter the connection token",
-            password: true,
-        });
-        return raw;
+  async pickToken(): Promise<string | undefined> {
+    const raw = await window.showInputBox({
+      placeHolder: "enter the connection token",
+      password: true,
+    });
+    return raw;
+  }
+
+  async resolveAuthority(
+    label: string,
+    channel: OutputChannel,
+  ): Promise<ResolvedAuthority> {
+    channel.append(`connecting to ${label}...`);
+
+    const hosts = (await this.getHostList()).filter((h) => h.label === label);
+    if (!hosts || hosts.length === 0) {
+      throw RemoteAuthorityResolverError.NotAvailable(
+        `Host ${label} is not available.`,
+        true,
+      );
     }
-
-    async resolveAuthority(
-        label: string,
-        channel: OutputChannel,
-    ): Promise<ResolvedAuthority> {
-        channel.append(`connecting to ${label}...`);
-
-        const hosts = (await this.getHostList()).filter(h => h.label === label);
-        if (!hosts || hosts.length === 0) {
-            throw RemoteAuthorityResolverError.NotAvailable(`Host ${label} is not available.`, true);
+    const host = hosts[0];
+    if (host instanceof PlainHostItem) {
+      if (typeof host.connectionToken === "boolean") {
+        if (!host.connectionToken) {
+          return new ResolvedAuthority(host.host, host.port);
+        } else {
+          const token = await this.pickToken();
+          if (!token) {
+            throw new Error("no token specified");
+          }
+          return new ResolvedAuthority(host.host, host.port, token);
         }
-        const host = hosts[0];
-        if (host instanceof PlainHostItem) {
-            if (typeof host.connectionToken === "boolean") {
-                if (!host.connectionToken) {
-                    return new ResolvedAuthority(host.host, host.port);
-                } else {
-                    const token = await this.pickToken();
-                    if (!token) {
-                        throw new Error("no token specified");
-                    }
-                    return new ResolvedAuthority(host.host, host.port, token);
-                }
-            } else {
-                return new ResolvedAuthority(host.host, host.port, host.connectionToken);
-            }
-        }
-        throw RemoteAuthorityResolverError.NotAvailable(`Host ${label} is not configured.`, true);
+      } else {
+        return new ResolvedAuthority(
+          host.host,
+          host.port,
+          host.connectionToken,
+        );
+      }
     }
+    throw RemoteAuthorityResolverError.NotAvailable(
+      `Host ${label} is not configured.`,
+      true,
+    );
+  }
 }

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -1,0 +1,85 @@
+import * as vscode from "vscode";
+import type { Host, HostBase } from "./remotesView";
+import { ScriptHostItem } from "./remotesView";
+import { type CustomScript, runScript } from "./script";
+
+async function pickToken(): Promise<string | undefined> {
+  const raw = await vscode.window.showInputBox({
+    placeHolder: "enter the connection token",
+    password: true,
+  });
+  return raw;
+}
+
+export class RemoteResolver {
+  private listener: CustomScript | undefined = undefined;
+
+  constructor(
+    private host: Host,
+    private progress: vscode.Progress<{ message?: string; increment?: number }>,
+    private output: vscode.OutputChannel
+  ) {}
+
+  initialize(): Promise<void> {
+    return this._startListener();
+    this.progress.report({ message: "connecting", increment: 50 });
+    this.output.appendLine(`connecting to ${this.host.name}...`);
+  }
+
+  dispose() {
+    this.listener?.terminate();
+    this.listener = undefined;
+  }
+
+  async resolveAuthority(): Promise<vscode.ResolvedAuthority> {
+    if (this.host.connectionToken === true) {
+      const token = await pickToken();
+      if (!token) {
+        throw new Error("no token specified");
+      }
+      return new vscode.ResolvedAuthority(
+        this.host.host,
+        this.host.port,
+        token
+      );
+    } else {
+      return new vscode.ResolvedAuthority(
+        this.host.host,
+        this.host.port,
+        this.host.connectionToken || undefined
+      );
+    }
+  }
+
+  _startListener(): Promise<void> {
+    if (this.host instanceof ScriptHostItem) {
+      this.progress.report({ message: "running listen script", increment: 0 });
+      const host: ScriptHostItem = this.host;
+      this.output.appendLine(`listenScript: ${host.listenScript}`);
+      const listener = runScript({
+        cwd: host.localDirectory,
+        script: host.listenScript,
+        output: this.output,
+        readyRegexp: host.listenScriptReady,
+      });
+      this.listener = listener;
+      return new Promise((resolve, reject) => {
+        listener.once("ready", () => {
+          this.output.appendLine("listenScript is ready");
+          resolve();
+        });
+        listener.once("exit", (code) => {
+          if (code === 0) {
+            // Process exited successfully, assume that it's listening now?
+            this.output.appendLine("listenScript finished without error");
+            resolve();
+          } else {
+            reject(new Error("listenScript failed"));
+          }
+        });
+      });
+    } else {
+      return Promise.resolve();
+    }
+  }
+}

--- a/src/script.ts
+++ b/src/script.ts
@@ -1,0 +1,74 @@
+import * as vscode from "vscode";
+import * as child_process from "child_process";
+import * as EventEmitter from "events";
+
+/**
+ * Events:
+ * - ready: when the script is ready, varies per script.
+ * - exit: ChildProcess exit event
+ */
+export class CustomScript extends EventEmitter {
+  constructor(private signal: AbortController) {
+    super();
+  }
+
+  /** Terminate the running script. */
+  terminate() {
+    this.signal.abort();
+  }
+}
+
+export type RunScriptArgs = {
+  cwd: string;
+  script: string;
+  env?: Record<string, string>;
+  output: vscode.OutputChannel;
+  readyRegexp?: string;
+};
+
+export function runScript({
+  cwd,
+  script,
+  env,
+  output,
+  readyRegexp: readyRegexpStr,
+}: RunScriptArgs): CustomScript {
+  const readyRegexp = readyRegexpStr ? new RegExp(readyRegexpStr) : undefined;
+  const abortController = new AbortController();
+  const child = child_process.spawn(script, {
+    cwd,
+    env,
+    shell: true,
+    stdio: ["ignore", "pipe", "pipe"],
+    signal: abortController.signal,
+  } as child_process.SpawnOptionsWithStdioTuple<
+    child_process.StdioNull,
+    child_process.StdioPipe,
+    child_process.StdioPipe
+  >);
+  const customScript = new CustomScript(abortController);
+  child.stdout.on("data", (data) => {
+    output.append(data.toString("utf-8"));
+    if (readyRegexp && readyRegexp.test(data.toString("utf-8"))) {
+      customScript.emit("ready");
+    }
+  });
+  child.stderr.on("data", (data) => {
+    output.append(data.toString("utf-8"));
+    if (readyRegexp && readyRegexp.test(data.toString("utf-8"))) {
+      customScript.emit("ready");
+    }
+  });
+  child.on("error", (err) => {
+    output.appendLine(`Failed to run script: ${err}`);
+  });
+  child.on("exit", (code, signal) => {
+    if (code !== 0) {
+      output.appendLine(
+        `Script failed with exit code ${code} ${signal ? ` (${signal})` : ""}`
+      );
+    }
+    customScript.emit("exit", code, signal);
+  });
+  return customScript;
+}


### PR DESCRIPTION
**This is a work in progress and not ready to be merged.** I recommend reviewing this PR by each commit rather than the overall "files changed" view. Closes #8.

This PR adds a new type of remote called `script`, which allows the user to specify a custom shell script to use to start an REH before connecting to it.

Remaining items:
- [x] Add a `listenScript` which is a short- or long-running process that is expected to listen on the configured host/port.
- [x] Add `listenScriptReady` which is a regex. When the `listenScript` outputs the regex, it is expected to be ready to accept connections. Note: the `listenScript` can also cleanly exit, but then Remote OSS cannot shut down the process when disconnecting.
- [ ] Support `connectScript` which is a script that is expected to directly talk to an REH over stdio (required for environments like devcontainers where port forwards cannot be added ad-hoc).
- [ ] Modify `connectionToken` behavior: `true` will cause Remote OSS to autogenerate a connection token instead of prompting, which will be provided to the scripts via an environment variable.
- [ ] Expose some useful environment variables to the scripts: `REMOTE_HOST`, `REMOTE_PORT`, `REH_VERSION`, `CONNECTION_TOKEN`.
- [ ] Verify that reconnections work in a sane way.
- [ ] Make the connection process cancelable.
- [ ] Document everything and provide an example devcontainer configuration.
- [ ] Add support for custom scripts accessible via command palette (e.g. "restart devcontainer").
- [ ] Investigate running the scripts as a process group so that it isn't just the parent process which gets killed when disconnecting.
- [ ] Remove the "manual" item from the top of the GUI and just put all configured hosts in the root (or allow the user to create a custom hierarchy)