### PR TITLE
encode labels so they survive a parser round-trip

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,9 @@ Have fun!
 
 ...
 
+### 0.0.4
+Properly encode the remote label so it survives a round-trip through the URI parser.
+
 ### 0.0.3
 Enabled port view and added an example update bash script.
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "remote-oss",
     "displayName": "Remote (OSS)",
     "description": "Remote (OSS)",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "publisher": "xaberus",
     "repository": {
         "url": "https://github.com/xaberus/vscode-remote-oss"


### PR DESCRIPTION
Properly encode the remote label so it survives a round-trip through the URI parser.


The proposed solution (hex encoding the label) is for example:
```yaml
label: "Bee reh-8000"
```
will turn into
```yaml
authority: "remote-oss+426565207265682d38303030"
```
where the part after `remote-oss+` is the hex-encoded label.